### PR TITLE
Fix math rendering in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,36 +431,35 @@ Arguments:
 ## Metric
 ### Metric core competition (congestion classes)
 We use masked cross-entropy loss on congestion classes:
-```math
-\ell(\hat{y}, y) = \sum_{n=1}^N \frac{1}{\sum_{n=1}^N w_{y_n} \cdot \mathbb{1}\{y_n \not= \text{ignore\_index}\}} l_n, \quad
-          l_n = - w_{y_n} \log \frac{\hat{y}_{n,y_n}+\varepsilon}{\sum_{c=0}^{C-1} \hat{y}_{n,c}+\varepsilon}
-          \cdot \mathbb{1}\{y_n \not= \text{ignore\_index}\}
 
+ 
 
-```
+$$\ell(\hat{y}, y) = \sum_{n=1}^N \frac{1}{\Sigma_{n=1}^N   w_{y_n} \cdot \mathbb{1}\{y_n \not= \text{ignore}\\\_\text{index}\}} l_n, \quad
+          l_n = - w_{y_n} \log \frac{\hat{y}_{n,y_n}+\varepsilon}{\sum_{c=0}^{C-1} \hat{y}_{n,c}+\varepsilon} \cdot \mathbb{1}\{y_n \not= \text{ignore}\\\_\text{index}\}$$
 
+ 
 where
-* $`\hat{y} \in \mathbb{R}^{N \times C}`$ is the input (probabilities, if logits are used, then replace $`x_{n,c}`$ and $`y_n`$ by $`\exp(x_{n,c})`$ and $`\exp(y_n)`$),
-* $`y \in \{0,...,C-1\}^N`$ is the target,
-* $`w \in \mathbb{R}^C`$ is the class weight,
-* $`C \in \mathbb{N}`$ is the number of classes, and
-* $`N \in \mathbb{N}`$ is the number of samples
-* $`\varepsilon \in \mathbb{R}^+ `$ is small constant preventing overflow in $`\log(0)`$
-* $`\text{ignore\_index} \in C \cup \{\bot\} \in `$ specifies a target value that is ignored or none ($`\bot`$)
+* $\hat{y} \in \mathbb{R}^{N \times C}$ is the input (probabilities, if logits are used, then replace $x_{n,c}$ and $y_n$ by $\exp(x_{n,c})$ and $\exp(y_{n})$ ),
+* $y \in \\{0,...,C-1\\}^N$ is the target,
+* $w \in \mathbb{R}^C$ is the class weight,
+* $C \in \mathbb{N}$ is the number of classes,
+* $N \in \mathbb{N}$ is the number of samples,
+* $\varepsilon \in \mathbb{R}^+$ is small constant preventing overflow in $\log(0)$,
+* $\text{ignore}\\\_\text{index} \in C \cup \{\bot\}$ specifies a target value that is ignored or none ( $\bot$ ).
 
 Cross-entropy loss will penalize small predicted probabilities disproportionately.
 
 In our setting,
-* $`C=4`$ and $`\text{ignore\_index}=0`$, i.e. we always **mask** on unclassified edges in ground truth
+* $C=4$ and $\text{ignore}\\\_\text{index}=0$, i.e., we always **mask** on unclassified edges in ground truth
   * 0 = unclassified
   * 1 = green (uncongested)
   * 2 = yellow (slowed down)
   * 3 = red (congest)
-* $`N`$ goes over edges and timestamps
-* $`w`$ macro averaging: $`w_c = \frac{N}{|C| \cdot \sum_{i=1}^N{\mathbb{1}\{y_i = c\}}}`$ for $`c \in C`$ simply calculates the mean for each ground truth class, giving equal weight to each class ([scikit multiclas classification](https://scikit-learn.org/stable/modules/model_evaluation.html#multiclass-and-multilabel-classification)). In problems where infrequent classes are nonetheless important, macro-averaging may be a means of highlighting their performance.  In our case, since we have more red than yellow than green in all cities and since we're interested in capturing congested situations well, we take this approach.
+* $N$ goes over edges and timestamps
+* $w$ macro averaging: $w_c = \frac{N}{|C| \cdot \Sigma_{i=1}^N{\mathbb{1}\{y_i = c\}}}$ for $c \in C$ simply calculates the mean for each ground truth class, giving equal weight to each class ([scikit multiclas classification](https://scikit-learn.org/stable/modules/model_evaluation.html#multiclass-and-multilabel-classification)). In problems where infrequent classes are nonetheless important, macro-averaging may be a means of highlighting their performance.  In our case, since we have more red than yellow than green in all cities and since we're interested in capturing congested situations well, we take this approach.
 
 We provide
-* the weights $`w`$ for each city
+* the weights $w$ for each city
 * average the macro-averaged city scores of the 3 cities to get an overall score.
 
 


### PR DESCRIPTION
Hello,

There are some issues with the math not rendering correctly when looking at the readme file. Currently, it is shown as code with surrounding $ signs which is very hard to read, for example, $`w`$. This PR should fix the issue.

Some additional notes:

- The \text{ignore_index} have issues rendering in github markdown due to the '_' so I had to replace it with \text{ignore}\\\_\text{index}, see: https://groups.google.com/g/mathjax-users/c/wSh6-hSIUpQ/m/d53b0sB1SKcJ

- Directly using a sum in the denominator of a fraction renders incorrectly so I had to replace \sum with \Sigma, visually it looks the same.

- The line $`\text{ignore\_index} \in C \cup \{\bot\} \in `$ ends with a \in so the math does not render at all. I removed the \in to read $\text{ignore}\\\_\text{index} \in C \cup \{\bot\}$ but if the dimensions should be shown it needs to be readded.